### PR TITLE
Support for the creation of a GNS3 appliance file

### DIFF
--- a/platform/vs/README.gns3.md
+++ b/platform/vs/README.gns3.md
@@ -1,0 +1,17 @@
+HOWTO Create a GNS3 Appliance File (.gns3a)
+
+
+Execute the command sonic-gns3.sh
+
+
+For instance: 
+
+./sonic-gns3a.sh -h
+
+sonic-gns3a.sh [ -r <ReleaseNumber> ] -b <SONiC VS image: sonic-vs.image>
+e.g.: sonic-gns3a.sh -r 1.1 -b <store_path>/sonic-vs.img
+
+For more information about GNS3, please refer to:
+
+https://gns3.com/
+

--- a/platform/vs/sonic-gns3a.sh
+++ b/platform/vs/sonic-gns3a.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# This script creates a .gns3a SONiC appliance file
+IMGFILE="sonic-vs.image"
+RELEASE="latest"
+
+usage() {
+    echo "`basename $0` [ -r <ReleaseNumber> ] -b <SONiC VS image: sonic-vs.image>"
+    echo "e.g.: `basename $0` -r 1.1 -b <store_path>/sonic-vs.image"
+    exit 0
+}
+
+while getopts "r:b:h" arg; do
+  case $arg in
+    h)
+	usage
+	;;
+    r)
+	RELEASE=$OPTARG
+	;;
+    b)
+	IMGFILE=$OPTARG
+	;;
+  esac
+done
+
+if [ ! -e ${IMGFILE} ]; then
+    echo "ERROR: ${IMGFILE} not found"
+    exit 2
+fi
+
+
+MD5SUMIMGFILE=`md5sum  ${IMGFILE} | cut -f 1 -d " "`
+LENIMGFILE=`stat -c %s ${IMGFILE}`
+GNS3APPNAME="SONiC-${RELEASE}.gns3a"
+NAMEIMGFILE=`basename $IMGFILE`
+
+echo "
+{
+    \"name\": \"SONiC\",
+    \"category\": \"router\",
+    \"description\": \"SONiC Virtual Switch/Router\n\",
+    \"vendor_name\": \"SONiC\",
+    \"vendor_url\": \"https://azure.github.io/SONiC/\",
+    \"product_name\": \"SONiC\",
+    \"product_url\": \"https://azure.github.io/SONiC/\",
+    \"registry_version\": 3,
+    \"status\": \"experimental\",
+    \"maintainer\": \"SONiC\",
+    \"maintainer_email\": \"sonicproject@googlegroups.com\",
+    \"usage\": \"Supports SONiC release: ${RELEASE}\",
+    \"qemu\": {
+        \"adapter_type\": \"e1000\",
+        \"adapters\": 10,
+        \"ram\": 2048,
+        \"hda_disk_interface\": \"virtio\",
+        \"arch\": \"x86_64\",
+        \"console_type\": \"telnet\",
+        \"boot_priority\": \"d\",
+        \"kvm\": \"require\"
+    },
+    \"images\": [
+        {
+            \"filename\": \"${NAMEIMGFILE}\",
+            \"version\": \"${RELEASE}\",
+            \"md5sum\": \"${MD5SUMIMGFILE}\",
+            \"filesize\": ${LENIMGFILE}
+        }
+    ],
+    \"versions\": [
+        {
+            \"name\": \"${RELEASE}\",
+            \"images\": {
+                \"hda_disk_image\": \"${NAMEIMGFILE}\"
+            }
+        }
+    ]
+}
+
+" > ${GNS3APPNAME}
+


### PR DESCRIPTION
**- What I did**
Added a script. The script is executed offline (does not impact the build or the SONIC target)

**- How I did it**
Generate a standard GNS3 appliance template.
 
**- How to verify it**
Execute the script:
./sonic-gns3a.sh -r MyRelease -b <store_path>/sonic-vs.image"

Import the resulting GNS3 app file into a GNS3 environment
Please refer to the file README.gns3.md for details (and the online GNS3 documentation)

**- Description for the changelog**
The script sonic-gns3a.sh creates a GNS3 appliance flle, that points to a sonin-vs.img (SONiC Virtual Switch).

The appliance file (and sonic-vs.img file) can subsequently be imported into a GNS3 simulation environment.

